### PR TITLE
Add route to get related-urls owned by given provider

### DIFF
--- a/src/cmr/graph/collections/core.clj
+++ b/src/cmr/graph/collections/core.clj
@@ -49,3 +49,7 @@
 (defn get-concept-ids-by-urls
   [conn urls]
   (cypher/tquery conn (query/get-concept-ids-by-urls urls)))
+
+(defn get-urls-via-provider
+  [conn provider]
+  (cypher/tquery conn (query/get-urls-via-provider provider)))

--- a/src/cmr/graph/queries/neo4j/collections.clj
+++ b/src/cmr/graph/queries/neo4j/collections.clj
@@ -17,3 +17,8 @@
   [urls]
   (format "match (c:Collection)-[:LINKS_TO]->(u:Url) where u.name in [%s] return c.conceptId;"
           (string/join "," (map #(format "'%s'" %) urls))))
+
+(defn get-urls-via-provider
+  [provider]
+  (format "match (p:Provider)<-[:OWNED_BY]-(c:Collection)-[:LINKS_TO]->(u:Url) where p.name='%s' return u.name;"
+          provider))

--- a/src/cmr/graph/rest/handler.clj
+++ b/src/cmr/graph/rest/handler.clj
@@ -99,6 +99,14 @@
           concept-ids (distinct (map #(get % "c.conceptId") result))]
       (response/json request concept-ids))))
 
+(defn get-urls-via-provider
+  [conn]
+  (fn [request]
+    (let [provider (get-in request [:path-params :provider-name])
+          result (collections/get-urls-via-provider conn provider)
+          urls (distinct (map #(get % "u.name") result))]
+      (response/json request urls))))
+
 (defn import-collection-data
   "Imports all of our collection data."
   [conn]

--- a/src/cmr/graph/rest/route.clj
+++ b/src/cmr/graph/rest/route.clj
@@ -36,7 +36,10 @@
   (let [conn (neo4j/get-conn httpd-component)]
     [["/relationships/related-urls/collections/:concept-id"
       {:get (handler/get-collections-via-related-urls conn)
-       :options handler/ok}]]))
+       :options handler/ok}]
+     ["/relationships/providers/related-urls/:provider-name"
+       {:get (handler/get-urls-via-provider conn)
+        :options handler/ok}]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;   CMR Elasticsearch Graph Routes   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
The query finds all linked related-urls in collections owned by said provider. Example:

```
curl -XGET http://localhost:3012/relationships/providers/related-urls/NOAA_NCEI
```